### PR TITLE
Pool.withResource() should take () -> FutureOr<T>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+
+* Fix the type annotation of `Pool.withResource()` to indicate that it takes
+  `() -> FutureOr<T>`.
+
 ## 1.3.0
 
 * Add a `Pool.done` getter that returns the same future returned by

--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -113,7 +113,7 @@ class Pool {
   /// Future.
   ///
   /// The return value of [callback] is piped to the returned Future.
-  Future/*<T>*/ withResource/*<T>*/(/*=T*/ callback()) {
+  Future<T> withResource<T>(FutureOr<T> callback()) {
     if (isClosed) {
       throw new StateError(
           "withResource() may not be called on a closed Pool.");
@@ -123,8 +123,8 @@ class Pool {
     // synchronously in case the pool is closed immediately afterwards. Async
     // functions have an asynchronous gap between calling and running the body,
     // and [close] could be called during that gap. See #3.
-    return request().then/*<Future<T>>*/((resource) {
-      return new Future/*<T>*/.sync(callback).whenComplete(resource.release);
+    return request().then<Future<T>>((resource) {
+      return new Future<T>.sync(callback).whenComplete(resource.release);
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pool
-version: 1.3.0
+version: 1.3.1
 author: Dart Team <misc@dartlang.org>
 description: A class for managing a finite pool of resources.
 homepage: https://github.com/dart-lang/pool

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   async: "^1.4.0"
   stack_trace: ">=0.9.2 <2.0.0"
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: ">=1.22.0 <2.0.0"
 dev_dependencies:
   fake_async: ">=0.1.0 <0.2.0"
   test: ">=0.12.0 <0.13.0"


### PR DESCRIPTION
Closes #6