### PR TITLE
Zone.strong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Update to make the code work with strong-mode clean Zone API.
 
+## 1.3.1
+
+* Fix the type annotation of `Pool.withResource()` to indicate that it takes
+  `() -> FutureOr<T>`.
+
 ## 1.3.0
 
 * Add a `Pool.done` getter that returns the same future returned by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 1.3.1
+## 1.3.2
 
-* Fix the type annotation of `Pool.withResource()` to indicate that it takes
-  `() -> FutureOr<T>`.
+* Update to make the code work with strong-mode clean Zone API.
 
 ## 1.3.0
 

--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -183,8 +183,7 @@ class Pool {
       _allocatedResources--;
       if (_allocatedResources == 0) _closeGroup.close();
     } else {
-      _onReleaseCallbacks.add(
-          Zone.current.bindCallback(onRelease, runGuarded: false));
+      _onReleaseCallbacks.add(Zone.current.bindCallback(onRelease));
     }
   }
 

--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -183,7 +183,9 @@ class Pool {
       _allocatedResources--;
       if (_allocatedResources == 0) _closeGroup.close();
     } else {
-      _onReleaseCallbacks.add(Zone.current.bindCallback(onRelease));
+      var zone = Zone.current;
+      var registered = zone.registerCallback(onRelease);
+      _onReleaseCallbacks.add(() => zone.run(registered));
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pool
-version: 1.3.1
+version: 1.3.2
 author: Dart Team <misc@dartlang.org>
 description: A class for managing a finite pool of resources.
 homepage: https://github.com/dart-lang/pool

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   async: "^1.4.0"
   stack_trace: ">=0.9.2 <2.0.0"
 environment:
-  sdk: ">=1.25.0 <2.0.0"
+  sdk: ">=2.0.0-dev.0.1 <2.0.0-dev.infinity"
 dev_dependencies:
   fake_async: ">=0.1.0 <0.2.0"
   test: ">=0.12.0 <0.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pool
-version: 1.3.3
+version: 1.3.2
 author: Dart Team <misc@dartlang.org>
 description: A class for managing a finite pool of resources.
 homepage: https://github.com/dart-lang/pool

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   async: "^1.4.0"
   stack_trace: ">=0.9.2 <2.0.0"
 environment:
-  sdk: ">=2.0.0-dev.0.1 <2.0.0-dev.infinity"
+  sdk: ">=1.22.0 <2.0.0"
 dev_dependencies:
   fake_async: ">=0.1.0 <0.2.0"
   test: ">=0.12.0 <0.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pool
-version: 1.3.2
+version: 1.3.3
 author: Dart Team <misc@dartlang.org>
 description: A class for managing a finite pool of resources.
 homepage: https://github.com/dart-lang/pool
@@ -7,7 +7,7 @@ dependencies:
   async: "^1.4.0"
   stack_trace: ">=0.9.2 <2.0.0"
 environment:
-  sdk: ">=1.22.0 <2.0.0"
+  sdk: ">=1.25.0 <2.0.0"
 dev_dependencies:
   fake_async: ">=0.1.0 <0.2.0"
   test: ">=0.12.0 <0.13.0"


### PR DESCRIPTION
The `dart:async` zone API is in the process of becoming strong-mode clean.
This patch fixes a breakage introduced by this change.