### PR TITLE
Fix: Throw ArgumentError if poolSize <= 0

### DIFF
--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -79,6 +79,10 @@ class Pool {
   /// all pending [request] futures will throw a [TimeoutException]. This is
   /// intended to avoid deadlocks.
   Pool(this._maxAllocatedResources, {Duration timeout}) : _timeout = timeout {
+    if (_maxAllocatedResources <= 0) {
+      throw ArgumentError('pool limit should be > 0');
+    }
+
     if (timeout != null) {
       // Start the timer canceled since we only want to start counting down once
       // we've run out of available resources.

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -436,6 +436,10 @@ void main() {
       completer.completeError("oh no!");
     });
   });
+
+  test("throw error when pool limit <= 0", () {
+    expect(() => Pool(-1), throwsArgumentError);
+  });
 }
 
 /// Returns a function that will cause the test to fail if it's called.


### PR DESCRIPTION
Fix https://github.com/dart-lang/pool/issues/20