### PR TITLE
expose resources

### DIFF
--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -36,10 +36,8 @@ class Pool {
   /// first regardless of what order the `onRelease` callbacks complete in.
   final _onReleaseCompleters = Queue<Completer<PoolResource>>();
 
-  final int _maxAllocatedResources;
-
   /// The maximum number of resources that may be allocated at once.
-  int get maxAllocatedResources => _maxAllocatedResources;
+  final int maxAllocatedResources;
 
   int _allocatedResources = 0;
 
@@ -48,7 +46,7 @@ class Pool {
 
   /// The status of the pool, whether it can provide a resource.
   bool get hasAvailableResources =>
-      _maxAllocatedResources != _allocatedResources;
+      maxAllocatedResources != _allocatedResources;
 
   /// The timeout timer.
   ///

--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -36,11 +36,19 @@ class Pool {
   /// first regardless of what order the `onRelease` callbacks complete in.
   final _onReleaseCompleters = Queue<Completer<PoolResource>>();
 
-  /// The maximum number of resources that may be allocated at once.
   final int _maxAllocatedResources;
 
-  /// The number of resources that are currently allocated.
+  /// The maximum number of resources that may be allocated at once.
+  int get maxAllocatedResources => _maxAllocatedResources;
+
   int _allocatedResources = 0;
+
+  /// The number of resources that are currently allocated.
+  int get allocatedResources => _allocatedResources;
+
+  /// The status of the pool, whether it can provide a resource.
+  bool get hasAvailableResources =>
+      _maxAllocatedResources != _allocatedResources;
 
   /// The timeout timer.
   ///

--- a/lib/pool.dart
+++ b/lib/pool.dart
@@ -17,7 +17,7 @@ import 'package:stack_trace/stack_trace.dart';
 /// The pool will ensure that only a certain number of [PoolResource]s may be
 /// allocated at once.
 class Pool {
-  /// Completers for requests beyond the first [_maxAllocatedResources].
+  /// Completers for requests beyond the first [maxAllocatedResources].
   ///
   /// When an item is released, the next element of [_requestedResources] will
   /// be completed.
@@ -84,9 +84,9 @@ class Pool {
   /// If [timeout] is passed, then if that much time passes without any activity
   /// all pending [request] futures will throw a [TimeoutException]. This is
   /// intended to avoid deadlocks.
-  Pool(this._maxAllocatedResources, {Duration? timeout}) : _timeout = timeout {
-    if (_maxAllocatedResources <= 0) {
-      throw ArgumentError.value(_maxAllocatedResources, 'maxAllocatedResources',
+  Pool(this.maxAllocatedResources, {Duration? timeout}) : _timeout = timeout {
+    if (maxAllocatedResources <= 0) {
+      throw ArgumentError.value(maxAllocatedResources, 'maxAllocatedResources',
           'Must be greater than zero.');
     }
 
@@ -106,7 +106,7 @@ class Pool {
       throw StateError('request() may not be called on a closed Pool.');
     }
 
-    if (_allocatedResources < _maxAllocatedResources) {
+    if (_allocatedResources < maxAllocatedResources) {
       _allocatedResources++;
       return Future.value(PoolResource._(this));
     } else if (_onReleaseCallbacks.isNotEmpty) {
@@ -204,7 +204,7 @@ class Pool {
 
       assert(doneFuture == null);
       var futures = Iterable<Future<void>>.generate(
-          _maxAllocatedResources, (i) => withResource(() => run(i)));
+          maxAllocatedResources, (i) => withResource(() => run(i)));
       doneFuture = Future.wait(futures, eagerError: true)
           .then<void>((_) {})
           .catchError(controller.addError);


### PR DESCRIPTION
This PR exposes `_maxAllocatedResources`, `_allocatedResources` and an extra property `hasAvailableResources` to be able to inspect the current status of the pool. This can be useful for short-curcuiting a request for example:

```dart
var p = Pool(1);

var pr = await p.request();

if (!p.hasAvailableResources) {
  return;
}

var pr2 = await p.request();
```

This PR also fixes dart-lang/tools#1557 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
  
